### PR TITLE
Keyboard hitbox

### DIFF
--- a/WordleWithFriends/Views/CustomKeyboard/KeyboardRow.swift
+++ b/WordleWithFriends/Views/CustomKeyboard/KeyboardRow.swift
@@ -9,8 +9,8 @@ import UIKit
 
 final class KeyboardRow: UIStackView {
   public struct Layout {
-    static let interKeySpacing = 4.0
-    static let specialKeySpacing = 8.0
+    static let interKeySpacing = 0.0
+    static let specialKeySpacing = 4.0
     static let specialKeyWidthMultiplier = 1.5
     static let heightToWidthRatio = 1.3333
   }

--- a/WordleWithFriends/Views/CustomKeyboard/KeyboardRow.swift
+++ b/WordleWithFriends/Views/CustomKeyboard/KeyboardRow.swift
@@ -12,7 +12,7 @@ final class KeyboardRow: UIStackView {
     static let interKeySpacing = 0.0
     static let specialKeySpacing = 4.0
     static let specialKeyWidthMultiplier = 1.5
-    static let heightToWidthRatio = 1.3333
+    static let heightToWidthRatio = 1.5
   }
   
   var delegate: KeyTapDelegate?

--- a/WordleWithFriends/Views/CustomKeyboard/WordleKeyboardInputView.swift
+++ b/WordleWithFriends/Views/CustomKeyboard/WordleKeyboardInputView.swift
@@ -18,8 +18,8 @@ protocol KeyTapDelegate {
 
 final class WordleKeyboardInputView: UIInputView {
   private struct Layout {
-    static let rowSpacing = 8.0
-    static let topPadding = 8.0
+    static let rowSpacing = 0.0
+    static let topPadding = 4.0
   }
   private var keyReferences: [WeakRef<WordleKeyboardKey>] = []
   private weak var forfeitKey: WordleKeyboardKey?

--- a/WordleWithFriends/Views/CustomKeyboard/WordleKeyboardKey.swift
+++ b/WordleWithFriends/Views/CustomKeyboard/WordleKeyboardKey.swift
@@ -92,12 +92,34 @@ final class WordleKeyboardKey: UIButton {
   private func setupView() {
     translatesAutoresizingMaskIntoConstraints = false
     
-    layer.cornerRadius = 3.0
-    layer.masksToBounds = true
+//    layer.cornerRadius = 3.0
+//    layer.masksToBounds = false
+//    layer.backgroundColor = guessState.associatedColor.cgColor
 //    backgroundColor = guessState.associatedColor
     
-    layer.frame = bounds.insetBy(dx: 2, dy: 2/*todo make this not 0 lmao */)
-    layer.backgroundColor = guessState.associatedColor.cgColor
+//    layer.frame = bounds.insetBy(dx: -2, dy: -2/*todo make this not 0 lmao */)
+//    layer.backgroundColor = guessState.associatedColor.cgColor
+    
+//    bounds = frame.insetBy(dx: 2, dy: 2)
+    
+    
+//    let backgroundLayer = CALayer()
+//    backgroundLayer.frame = bounds.insetBy(dx: 2, dy: 2)
+//    backgroundLayer.backgroundColor = guessState.associatedColor.cgColor
+//    layer.addSublayer(backgroundLayer)
+    
+    // OK FUCK IT WE'LL DO IT WITH SUBVIEWS!!! FUCKING PIECE OF SHIT!!!!!!!!!
+    
+    let backgroundSubview = UIView()
+    backgroundSubview.translatesAutoresizingMaskIntoConstraints = false
+    backgroundSubview.layer.cornerRadius = 3.0
+    backgroundSubview.isOpaque = true
+    backgroundSubview.backgroundColor = guessState.associatedColor
+    
+    addSubview(backgroundSubview)
+    backgroundSubview.pin(to: self, margins: .init(top: 1, left: 1.5, bottom: 1, right: 1.5))
+    sendSubviewToBack(backgroundSubview)
+    backgroundSubview.isUserInteractionEnabled = false
     
     titleLabel?.font = titleLabel?.font.withSize(24.0)
     titleLabel?.numberOfLines = 1

--- a/WordleWithFriends/Views/CustomKeyboard/WordleKeyboardKey.swift
+++ b/WordleWithFriends/Views/CustomKeyboard/WordleKeyboardKey.swift
@@ -93,8 +93,11 @@ final class WordleKeyboardKey: UIButton {
     translatesAutoresizingMaskIntoConstraints = false
     
     layer.cornerRadius = 3.0
-    layer.masksToBounds = false
-    backgroundColor = guessState.associatedColor
+    layer.masksToBounds = true
+//    backgroundColor = guessState.associatedColor
+    
+    layer.frame = bounds.insetBy(dx: 2, dy: 2/*todo make this not 0 lmao */)
+    layer.backgroundColor = guessState.associatedColor.cgColor
     
     titleLabel?.font = titleLabel?.font.withSize(24.0)
     titleLabel?.numberOfLines = 1

--- a/WordleWithFriends/Views/CustomKeyboard/WordleKeyboardKey.swift
+++ b/WordleWithFriends/Views/CustomKeyboard/WordleKeyboardKey.swift
@@ -46,7 +46,7 @@ final class WordleKeyboardKey: UIButton {
             addSubview(progressBar)
             sendSubviewToBack(progressBar)
           }
-          progressBar.pin(to: self)
+          progressBar.pin(to: self, margins: .init(top: 4, left: 1.5, bottom: 4, right: 1.5))
           
           progressBar.isHidden = true
           
@@ -107,7 +107,7 @@ final class WordleKeyboardKey: UIButton {
     self.backgroundView = backgroundSubview
 
     insertSubview(backgroundSubview, belowSubview: progressBar)
-    backgroundSubview.pin(to: self, margins: .init(top: 1, left: 2, bottom: 1, right: 1))
+    backgroundSubview.pin(to: self, margins: .init(top: 4, left: 1.5, bottom: 4, right: 1.5))
     
     sendSubviewToBack(backgroundSubview)
     backgroundSubview.isUserInteractionEnabled = false
@@ -117,7 +117,7 @@ final class WordleKeyboardKey: UIButton {
     setTitleColor(.label, for: .normal)
     addTarget(self, action: #selector(didTapKey), for: .touchUpInside)
   }
-
+  
   func updateGuessState(_ state: LetterState) {
     guard state.priority > guessState.priority else { return }
     guessState = state

--- a/WordleWithFriends/Views/CustomKeyboard/WordleKeyboardKey.swift
+++ b/WordleWithFriends/Views/CustomKeyboard/WordleKeyboardKey.swift
@@ -94,18 +94,6 @@ final class WordleKeyboardKey: UIButton {
   private func setupView() {
     translatesAutoresizingMaskIntoConstraints = false
     
-//    layer.cornerRadius = 3.0
-//    layer.masksToBounds = false
-//    layer.backgroundColor = guessState.associatedColor.cgColor
-//    backgroundColor = guessState.associatedColor
-    
-//    layer.frame = bounds.insetBy(dx: -2, dy: -2/*todo make this not 0 lmao */)
-//    layer.backgroundColor = guessState.associatedColor.cgColor
-    
-//    bounds = frame.insetBy(dx: 2, dy: 2)
-    
-    // OK FUCK IT WE'LL DO IT WITH SUBVIEWS!!! FUCKING PIECE OF SHIT!!!!!!!!!
-    
     let backgroundSubview = UIView()
     backgroundSubview.translatesAutoresizingMaskIntoConstraints = false
     backgroundSubview.layer.cornerRadius = 4.0
@@ -124,22 +112,7 @@ final class WordleKeyboardKey: UIButton {
     setTitleColor(.label, for: .normal)
     addTarget(self, action: #selector(didTapKey), for: .touchUpInside)
   }
-  
-//  override func didMoveToSuperview() {
-//    super.didMoveToSuperview()
-//
-//    layer.frame = bounds.insetBy(dx: -2, dy: -2/*todo make this not 0 lmao */)
-//    layer.backgroundColor = guessState.associatedColor.cgColor
-//  }
-//
-//  override func willMove(toSuperview newSuperview: UIView?) {
-//    super.willMove(toSuperview: newSuperview)
-//
-//    layer.frame = bounds.insetBy(dx: -2, dy: -2/*todo make this not 0 lmao */)
-//    layer.backgroundColor = guessState.associatedColor.cgColor
-//
-//  }
-  
+
   func updateGuessState(_ state: LetterState) {
     guard state.priority > guessState.priority else { return }
     guessState = state

--- a/WordleWithFriends/Views/CustomKeyboard/WordleKeyboardKey.swift
+++ b/WordleWithFriends/Views/CustomKeyboard/WordleKeyboardKey.swift
@@ -40,9 +40,14 @@ final class WordleKeyboardKey: UIButton {
           longPressGestureRecognizer.minimumPressDuration = minDuration
           addGestureRecognizer(longPressGestureRecognizer)
           
-          addSubview(progressBar)
+          if let backgroundView = backgroundView {
+            insertSubview(progressBar, aboveSubview: backgroundView)
+          } else {
+            addSubview(progressBar)
+            sendSubviewToBack(progressBar)
+          }
           progressBar.pin(to: self)
-          sendSubviewToBack(progressBar)
+          
           progressBar.isHidden = true
           
           titleLabel?.font = titleLabel?.font.withSize(22.0)
@@ -101,7 +106,7 @@ final class WordleKeyboardKey: UIButton {
     backgroundSubview.backgroundColor = guessState.associatedColor
     self.backgroundView = backgroundSubview
 
-    addSubview(backgroundSubview)
+    insertSubview(backgroundSubview, belowSubview: progressBar)
     backgroundSubview.pin(to: self, margins: .init(top: 1, left: 2, bottom: 1, right: 1))
     
     sendSubviewToBack(backgroundSubview)

--- a/WordleWithFriends/Views/CustomKeyboard/WordleKeyboardKey.swift
+++ b/WordleWithFriends/Views/CustomKeyboard/WordleKeyboardKey.swift
@@ -59,9 +59,11 @@ final class WordleKeyboardKey: UIButton {
   
   private var guessState: LetterState = .unchecked {
     didSet {
-      backgroundColor = guessState.associatedColor
+      backgroundView?.backgroundColor = guessState.associatedColor
     }
   }
+  
+  private var backgroundView: UIView?
   
   private var progressBarTimer: Timer?
   private var timerFireCount: Int = 0
@@ -102,22 +104,18 @@ final class WordleKeyboardKey: UIButton {
     
 //    bounds = frame.insetBy(dx: 2, dy: 2)
     
-    
-//    let backgroundLayer = CALayer()
-//    backgroundLayer.frame = bounds.insetBy(dx: 2, dy: 2)
-//    backgroundLayer.backgroundColor = guessState.associatedColor.cgColor
-//    layer.addSublayer(backgroundLayer)
-    
     // OK FUCK IT WE'LL DO IT WITH SUBVIEWS!!! FUCKING PIECE OF SHIT!!!!!!!!!
     
     let backgroundSubview = UIView()
     backgroundSubview.translatesAutoresizingMaskIntoConstraints = false
-    backgroundSubview.layer.cornerRadius = 3.0
+    backgroundSubview.layer.cornerRadius = 4.0
     backgroundSubview.isOpaque = true
     backgroundSubview.backgroundColor = guessState.associatedColor
-    
+    self.backgroundView = backgroundSubview
+
     addSubview(backgroundSubview)
-    backgroundSubview.pin(to: self, margins: .init(top: 1, left: 1.5, bottom: 1, right: 1.5))
+    backgroundSubview.pin(to: self, margins: .init(top: 1, left: 2, bottom: 1, right: 1))
+    
     sendSubviewToBack(backgroundSubview)
     backgroundSubview.isUserInteractionEnabled = false
     
@@ -126,6 +124,21 @@ final class WordleKeyboardKey: UIButton {
     setTitleColor(.label, for: .normal)
     addTarget(self, action: #selector(didTapKey), for: .touchUpInside)
   }
+  
+//  override func didMoveToSuperview() {
+//    super.didMoveToSuperview()
+//
+//    layer.frame = bounds.insetBy(dx: -2, dy: -2/*todo make this not 0 lmao */)
+//    layer.backgroundColor = guessState.associatedColor.cgColor
+//  }
+//
+//  override func willMove(toSuperview newSuperview: UIView?) {
+//    super.willMove(toSuperview: newSuperview)
+//
+//    layer.frame = bounds.insetBy(dx: -2, dy: -2/*todo make this not 0 lmao */)
+//    layer.backgroundColor = guessState.associatedColor.cgColor
+//
+//  }
   
   func updateGuessState(_ state: LetterState) {
     guard state.priority > guessState.priority else { return }


### PR DESCRIPTION
Adjust hitbox of keyboard so keys occupy full width and height but leaving in the visual gaps. This ensures that any taps in the "gaps" of the keys will still register.

#27 

<img width="506" alt="image" src="https://user-images.githubusercontent.com/3281451/158506036-48f6904d-8ebf-42a3-9bba-df0b74e341e3.png">
